### PR TITLE
resources: refit text and whitespace

### DIFF
--- a/app/components/Resources/CultureBox.tsx
+++ b/app/components/Resources/CultureBox.tsx
@@ -30,16 +30,20 @@ const CultureBox = ({
       data-testid={testIds.RESOURCES.CULTURE_BOX}
     >
       <div className="flex flex-col justify-center items-start p-8 md:p-12">
-        <h2 className="mb-5 text-2xl font-bold md:mb-6">{heading}</h2>
-        <p className="text-md mb-6 md:mb-8">{description}</p>
-        <Button size="lg" color="dark" outline href={ctaLink}>
-          {ctaLabel}
-        </Button>
+        <h2 className="mb-3 md:mb-6 text-xl md:text-2xl font-bold">
+          {heading}
+        </h2>
+        <p className="mb-6 md:mb-8 text-base md:text-lg">{description}</p>
+        <div className="w-full flex justify-center md:justify-start">
+          <Button size="lg" color="dark" outline href={ctaLink}>
+            {ctaLabel}
+          </Button>
+        </div>
       </div>
-      <div className="flex items-center justify-center px-8 py-8">
+      <div className="flex items-center justify-center md:px-8 md:py-8">
         <Image
           src={image.url}
-          className="w-full object-contain aspect-video"
+          className="w-full object-cover md:object-contain aspect-video"
           alt={imageAlt}
           width={image.width}
           height={image.height}

--- a/app/components/Resources/HistoricalBusinesses.tsx
+++ b/app/components/Resources/HistoricalBusinesses.tsx
@@ -48,7 +48,7 @@ const HistoricalBusinesses = ({
       <div className="flex items-center justify-center lg:col-span-2">
         <Image
           src={selectedBusiness.image.url}
-          className="w-full h-full object-contain aspect-square"
+          className="w-full h-full object-contain aspect-square md:aspect-video"
           alt={selectedBusiness.name}
           width={selectedBusiness.image.width}
           height={selectedBusiness.image.height}


### PR DESCRIPTION
Did the following edits:
- Reduced text size on mobile
- Centered buttons in the CulturalLandmarks
- Adjusted image aspect ratios

Fixes: #71