### PR TITLE
root: remove black outline on button hover

### DIFF
--- a/app/components/Benefits.tsx
+++ b/app/components/Benefits.tsx
@@ -62,7 +62,7 @@ const Benefits = ({ benefitsData }: { benefitsData: Benefit[] }) => {
             color="dark"
             size="lg"
             outline
-            className="text-white! border-white hover:bg-white hover:text-black!"
+            className="text-white! hover:text-black! border-white! hover:border-white! hover:bg-white shadow-none!"
             data-testid={testIds.BENEFITS.JOIN_BTN}
           >
             Join the chamber

--- a/app/components/CTA.tsx
+++ b/app/components/CTA.tsx
@@ -44,7 +44,7 @@ export default function CTA() {
             outline
             data-testid={testIds.CTA.APPLY_BTN}
             href="/join"
-            className="text-white! border-white hover:bg-white hover:text-black!"
+            className="text-white! hover:text-black! border-white! hover:border-white! hover:bg-white shadow-none!"
           >
             Apply now
           </Button>

--- a/app/components/Hero.tsx
+++ b/app/components/Hero.tsx
@@ -46,7 +46,7 @@ const Hero = ({ image }: { image: WixImage }) => {
               color="dark"
               size="lg"
               outline
-              className="text-white border-white hover:text-black! hover:bg-white w-full sm:w-auto"
+              className="text-white! hover:text-black! border-white! hover:border-white! hover:bg-white shadow-none! w-full sm:w-auto"
               href="/about"
             >
               Who we are

--- a/app/components/Layout/Header.tsx
+++ b/app/components/Layout/Header.tsx
@@ -71,7 +71,7 @@ function Header() {
               as="a"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-white border-white hover:text-black! hover:bg-white"
+              className="text-white! hover:text-black! border-white! hover:border-white! hover:bg-white shadow-none!"
             >
               Pay Fees
             </Button>
@@ -144,7 +144,7 @@ function Header() {
                 target="_blank"
                 rel="noopener noreferrer"
                 onClick={closeMenu}
-                className="text-white border-white hover:text-black! hover:bg-white"
+                className="text-white! hover:text-black! border-white! hover:border-white! hover:bg-white shadow-none!"
               >
                 Pay Fees
               </Button>

--- a/app/directory/page.tsx
+++ b/app/directory/page.tsx
@@ -73,7 +73,7 @@ export default function Directory() {
                 size="lg"
                 outline
                 onClick={handleLoadMore}
-                className="text-white border-white hover:text-black! hover:bg-white"
+                className="text-white! hover:text-black! border-white! hover:border-white! hover:bg-white shadow-none!"
               >
                 Load more
               </Button>


### PR DESCRIPTION
Previously, all the white buttons had a thin black outline. This PR removes that.

Fixes: #123