### PR TITLE
join: resize font and spacing

### DIFF
--- a/app/components/Join/MembershipForm.tsx
+++ b/app/components/Join/MembershipForm.tsx
@@ -62,7 +62,7 @@ export default function MembershipForm() {
   }
 
   return (
-    <div className="container mx-auto max-w-lg py-20">
+    <div className="container mx-auto max-w-lg px-[5%] py-20 md:px-0">
       <div className="mx-auto mb-8 w-full text-center md:mb-10 lg:mb-12">
         <h2 className="rb-5 mb-5 text-lg md:text-3xl font-bold md:mb-6 text-white">
           Join us

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -45,7 +45,7 @@ export default function Join() {
               </p>
             </div>
           </div>
-          <div className="grid grid-cols-1 items-start gap-y-12 md:grid-cols-2 md:gap-x-8 md:gap-y-16 lg:grid-cols-4">
+          <div className="grid grid-cols-1 items-start mx-auto gap-y-12 md:grid-cols-2 md:gap-x-8 md:gap-y-16 lg:grid-cols-4">
             <BenefitCard
               key="join-benefit-1"
               message="Promote your business through Chamber activities"
@@ -79,7 +79,7 @@ export default function Join() {
             We are here to answer your membership questions
           </p>
         </div>
-        <div className="grid auto-cols-fr grid-cols-1 items-center gap-x-12 gap-y-12 md:grid-cols-3 md:gap-y-16">
+        <div className="grid auto-cols-fr grid-cols-1 items-center gap-x-12 gap-y-12 xl:grid-cols-3 xl:gap-y-16">
           {contactInfo.map((contact, index) => {
             const Icon = contact.icon;
             return (


### PR DESCRIPTION
Previously, fonts and elements like the input fields were touching the edge of the screen on mobile phones and some tablets. This PR adjusts the font size and spacing of many elements better to fit various tablet and mobile phone screen sizes.

Fixes: #127 